### PR TITLE
Refactor Thread Handling and Improve Logging for Kafka Sink

### DIFF
--- a/src/query/kafka_psql_sink.rs
+++ b/src/query/kafka_psql_sink.rs
@@ -126,7 +126,10 @@ pub fn receive_event_from_kafka_queue(
     thread::spawn(move || {
         // get the last offset from kafka
         let last_offset = get_offset_from_kafka(topic.clone(), group.clone());
-        println!("last_offset: {:#?}", last_offset);
+        println!(
+            "last_offset for topic: {} and group: {} is {:#?}",
+            topic, group, last_offset
+        );
 
         // create an offset tracker
         let offset_tracker = Arc::new(OffsetManager::new(last_offset - 1));
@@ -331,9 +334,7 @@ pub fn psql_relayer_state_queue(
 
 /// Gets the last committed offset from Kafka for a topic/group
 pub fn get_offset_from_kafka(topic: String, group: String) -> i64 {
-    let broker = vec![std::env::var("BROKER")
-        .expect("missing environment variable BROKER")
-        .to_owned()];
+    let broker = vec![KAFKA_BROKER.clone()];
     let mut con = Consumer::from_hosts(broker)
         // .with_topic(topic)
         .with_group(group)

--- a/src/query/postgres_sql_init.rs
+++ b/src/query/postgres_sql_init.rs
@@ -146,7 +146,7 @@ fn create_relayer_state_queue_table() -> Result<(), r2d2_postgres::postgres::Err
         "CREATE TABLE IF NOT EXISTS public.relayer_state_queue (
             \"offset\" bigint NOT NULL,
             key VARCHAR(1024) NOT NULL,
-            payload json NOT NULL,
+            payload json NOT NULL
           );"
     );
     let mut client = POSTGRESQL_POOL_CONNECTION.get().unwrap();


### PR DESCRIPTION
This pull request refactors the thread management in main.rs by assigning thread handles to variables and joining them at shutdown for improved control and graceful termination. It also enhances logging clarity in kafka_psql_sink.rs by including topic and group information with offset logs, switches to using a constant for the Kafka broker, and makes a minor SQL formatting fix in postgres_sql_init.rs. These changes improve maintainability, debugging, and stability of the relayer-kafka-sink application.